### PR TITLE
Fix ObjectDisposedException in Cancellation token access (#19)

### DIFF
--- a/AsyncImageLoader.Avalonia/AdvancedImage.axaml.cs
+++ b/AsyncImageLoader.Avalonia/AdvancedImage.axaml.cs
@@ -189,8 +189,14 @@ public class AdvancedImage : ContentControl
 		var cancellationTokenSource = new CancellationTokenSource();
 
         var oldCancellationToken = Interlocked.Exchange(ref _updateCancellationToken, cancellationTokenSource);
-        oldCancellationToken?.Cancel();
-        oldCancellationToken?.Dispose();
+
+        try
+        {
+            oldCancellationToken?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
         
         if (source is null && CurrentImage is not ImageWrapper) {
             // User provided image himself
@@ -232,6 +238,11 @@ public class AdvancedImage : ContentControl
 			{
 				return null;
 			}
+	                finally
+		        {
+		                cancellationTokenSource.Dispose();
+			}
+   
 		}, CancellationToken.None);
 
 		if (cancellationTokenSource.IsCancellationRequested)


### PR DESCRIPTION
Changes:
- ignore ObjectDisposed exceptions during canceling of `oldCancellationToken`
- no longer dispose `oldCancellationToken` since it may be being used in another call
- instead we dispose the token source the current method created in a finally clause of the task