### PR TITLE
Added FallbackImage property

### DIFF
--- a/AsyncImageLoader.Avalonia/AdvancedImage.axaml.cs
+++ b/AsyncImageLoader.Avalonia/AdvancedImage.axaml.cs
@@ -178,7 +178,10 @@ public class AdvancedImage : ContentControl {
             ClearSourceIfUserProvideImage();
         else if (change.Property == CornerRadiusProperty)
             UpdateCornerRadius(change.GetNewValue<CornerRadius>());
-        else if (change.Property == BoundsProperty && CornerRadius != default) UpdateCornerRadius(CornerRadius);
+        else if (change.Property == BoundsProperty && CornerRadius != default)
+            UpdateCornerRadius(CornerRadius);
+        else if (change.Property == FallbackImageProperty && Source == null)
+            UpdateImage(null, null);
         base.OnPropertyChanged(change);
     }
 
@@ -200,6 +203,10 @@ public class AdvancedImage : ContentControl {
         catch (ObjectDisposedException) {
         }
 
+        if (source is null && FallbackImage != null) {
+            CurrentImage =  FallbackImage;
+        }
+
         if (source is null && CurrentImage is not ImageWrapper) {
             // User provided image himself
             return;
@@ -207,7 +214,6 @@ public class AdvancedImage : ContentControl {
 
         IsLoading = true;
         CurrentImage = null;
-
 
         var bitmap = await Task.Run(async () => {
             try {
@@ -252,9 +258,6 @@ public class AdvancedImage : ContentControl {
 
         if (cancellationTokenSource.IsCancellationRequested)
             return;
-
-        if (bitmap is null && FallbackImage != null)
-            bitmap = FallbackImage;
 
         CurrentImage = bitmap is null ? null : new ImageWrapper(bitmap);
         IsLoading = false;


### PR DESCRIPTION
This PR lets you set a fallback bitmap for if an image binding is set to null. Using a `Bitmap` means its a bit easier to cache in memory rather than every failure creating a new Bitmap

I may very well have missed how to do this with the library already, so my apologies if its already there.

Usage
```xaml				
<asyncImageLoader:AdvancedImage
		Loader="{x:Static app:App.ImageLoaderInstance}"
		FallbackImage="{x:Static app:App.FallbackImage}"
		Source="{Binding Path=., Converter={StaticResource MetadataImageConverter}}" />
```

```csharp
private static Bitmap fallbackImage;
public static Bitmap FallbackImage
{
    get
    {
        return fallbackImage ??= new Bitmap(AssetLoader.Open(new Uri("avares://WateryTart.Core/Assets/cover_dark.png")));
    }
}
```

`FallbackBinding` on Source only triggers when the binding itself fails, rather than returning empty/null strings.