### PR TITLE
Avalonia 12 support

### DIFF
--- a/AsyncImageLoader.Avalonia.Demo/App.axaml.cs
+++ b/AsyncImageLoader.Avalonia.Demo/App.axaml.cs
@@ -16,7 +16,7 @@ public class App : Application {
             desktop.MainWindow = new MainWindow {
                 DataContext = new MainWindowViewModel(),
             };
-            desktop.MainWindow.AttachDevTools();
+            this.AttachDeveloperTools();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/AsyncImageLoader.Avalonia.Demo/AsyncImageLoader.Avalonia.Demo.csproj
+++ b/AsyncImageLoader.Avalonia.Demo/AsyncImageLoader.Avalonia.Demo.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
 
-    <AvaloniaVersion>11.3.2</AvaloniaVersion>
+    <AvaloniaVersion>12.0.1</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets/avalonia-logo.ico" />
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Include="Avalonia.Diagnostics" />
-    <PackageReference Include="Avalonia.ReactiveUI" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" />
+    <PackageReference Include="ReactiveUI.Avalonia" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AsyncImageLoader.Avalonia\AsyncImageLoader.Avalonia.csproj" />

--- a/AsyncImageLoader.Avalonia.Demo/Controls/HamburgerMenu.axaml
+++ b/AsyncImageLoader.Avalonia.Demo/Controls/HamburgerMenu.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:AsyncImageLoader.Avalonia.Demo.Controls">
-  <Design.PreviewWith>
+  <!-- <Design.PreviewWith>
     <Border Width="400"
             Height="150">
       <controls:HamburgerMenu>
@@ -18,7 +18,7 @@
         <TabItem Header="Item2" />
       </controls:HamburgerMenu>
     </Border>
-  </Design.PreviewWith>
+  </Design.PreviewWith> -->
 
   <x:Double x:Key="PaneCompactWidth">40</x:Double>
   <x:Double x:Key="PaneExpandWidth">220</x:Double>
@@ -188,7 +188,7 @@
             </SplitView.Pane>
             <SplitView.Content>
               <DockPanel>
-                <Border Height="{StaticResource HeaderHeight}" DockPanel.Dock="Top">
+                <!-- <Border Height="{StaticResource HeaderHeight}" DockPanel.Dock="Top">
                   <TextBlock x:Name="HeaderHolder"
                              VerticalAlignment="Center"
                              Classes="h1"
@@ -202,7 +202,7 @@
                       </Transitions>
                     </TextBlock.Transitions>
                   </TextBlock>
-                </Border>
+                </Border> -->
                 <Border x:Name="BackgroundBorder">
                   <Border.Transitions>
                     <Transitions>
@@ -252,10 +252,10 @@
       <Setter Property="PaneBackground" Value="{TemplateBinding PaneBackground}" />
     </Style>
     <Style Selector="^ /template/ SplitView[DisplayMode=Overlay]">
-      <Setter Property="Background" Value="{Binding $parent[TabControl].ContentBackground}" />
+      <Setter Property="Background" Value="{Binding $parent[controls:HamburgerMenu].ContentBackground}" />
     </Style>
     <Style Selector="^ /template/ SplitView[DisplayMode=Inline] Border#BackgroundBorder">
-      <Setter Property="Background" Value="{Binding $parent[TabControl].ContentBackground}" />
+      <Setter Property="Background" Value="{Binding $parent[controls:HamburgerMenu].ContentBackground}" />
       <Setter Property="BoxShadow" Value="{StaticResource NavigationContentShadow}" />
     </Style>
     <Style Selector="^ /template/ SplitView[DisplayMode=Inline][IsPaneOpen=True] Border#BackgroundBorder">

--- a/AsyncImageLoader.Avalonia.Demo/Program.cs
+++ b/AsyncImageLoader.Avalonia.Demo/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.ReactiveUI;
+using ReactiveUI.Avalonia;
 
 namespace AsyncImageLoader.Avalonia.Demo;
 
@@ -18,5 +18,5 @@ class Program {
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .LogToTrace()
-            .UseReactiveUI();
+            .UseReactiveUI(rxui => { });
 }

--- a/AsyncImageLoader.Avalonia.Demo/Views/MainWindow.axaml.cs
+++ b/AsyncImageLoader.Avalonia.Demo/Views/MainWindow.axaml.cs
@@ -7,7 +7,6 @@ namespace AsyncImageLoader.Avalonia.Demo.Views;
 public partial class MainWindow : Window {
     public MainWindow() {
         InitializeComponent();
-        this.AttachDevTools();
     }
 
     private void InitializeComponent() {

--- a/AsyncImageLoader.Avalonia/AsyncImageLoader.Avalonia.csproj
+++ b/AsyncImageLoader.Avalonia/AsyncImageLoader.Avalonia.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>AsyncImageLoader</RootNamespace>
 
     <Title>AsyncImageLoader.Avalonia</Title>

--- a/AsyncImageLoader.Avalonia/AsyncImageLoader.Avalonia.csproj
+++ b/AsyncImageLoader.Avalonia/AsyncImageLoader.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>AsyncImageLoader</RootNamespace>
 
     <Title>AsyncImageLoader.Avalonia</Title>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>11.1.0</AvaloniaVersion>
+    <AvaloniaVersion>12.0.1</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" />
@@ -11,9 +11,11 @@
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageVersion Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
     <!--For _build-->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>12.0.1</AvaloniaVersion>
+    <AvaloniaVersion>12.0.0</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" />
@@ -11,11 +11,9 @@
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
-    <PackageVersion Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
     <!--For _build-->
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Well, it's not so much "Avalonia 12 support" as "only now works with Avalonia 12"

[Avalonia 12 introduced some breaking changes](https://docs.avaloniaui.net/docs/avalonia12-breaking-changes), the relevant ones here are
* dropped .NET Framework/.NET standard support, only .NET8 and up (10 is recommended)
* `Avalonia.Diagnostics` replaced by `AvaloniaUI.DiagnosticsSupport`
* `.AttachDevtools()` replaced by `.AttachDeveloperTools()`
