### PR TITLE
Fixed release Bitmap resources in ClearRamCache and only remove completed tasks

### DIFF
--- a/AsyncImageLoader.Avalonia/Loaders/RamCachedWebImageLoader.cs
+++ b/AsyncImageLoader.Avalonia/Loaders/RamCachedWebImageLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
@@ -39,6 +40,10 @@ public class RamCachedWebImageLoader : BaseWebImageLoader {
     }
 
     public void ClearRamCache() {
-        _memoryCache.Clear();
+        foreach (var key in _memoryCache.Keys.ToArray()) {
+            if (!_memoryCache.TryGetValue(key, out var bitmap) || !bitmap.IsCompleted) continue;
+            if (!_memoryCache.TryRemove(key, out bitmap) || !bitmap.IsCompletedSuccessfully) continue;
+            bitmap.Result?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the issue where Bitmap resources were not disposed, which could cause memory leaks.
Sorry for not properly disposing the resources in #40.